### PR TITLE
Switch from windows-2019 runners to windows-latest

### DIFF
--- a/.github/workflows/build-installers.yaml
+++ b/.github/workflows/build-installers.yaml
@@ -95,7 +95,7 @@ jobs:
 
   build_windows:
     name: Build Windows Installer
-    runs-on: windows-2019
+    runs-on: windows-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR replaces 'windows-2019' with 'windows-latest' in GitHub Actions workflows to ensure compatibility and leverage the latest features and security updates.